### PR TITLE
WIP: Preferences

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (rfi-file-monitor)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/rfi-file-monitor.iml" filepath="$PROJECT_DIR$/.idea/rfi-file-monitor.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/rfi-file-monitor.iml
+++ b/.idea/rfi-file-monitor.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (rfi-file-monitor)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="pytest" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 exclude rfi_file_monitor.egg-info
 recursive-include rfi_file_monitor/data *
+include rfi-instruments.yaml

--- a/rfi-instruments.yaml
+++ b/rfi-instruments.yaml
@@ -1,0 +1,12 @@
+electron microscope 1:
+  id: 123456
+  type: electron microscope
+  manufacturer: JEOL
+electron microscope 2:
+  id: 321456
+  type: electron microscope
+  manufacturer: JEOL
+nmr 1:
+  id: 234561
+  type: NMR
+  manufacturer: Bruker

--- a/rfi_file_monitor/application.py
+++ b/rfi_file_monitor/application.py
@@ -41,7 +41,7 @@ class Application(Gtk.Application):
             ("open", self.on_open),
             ("new", lambda *_: self.do_activate()),
             ("help-url", self.on_help_url, "s"),
-            ('hi', self.on_hi)
+            ('instr-setup', self.on_instr_setup),
         )
 
         # This doesn't work, which is kind of uncool
@@ -126,7 +126,7 @@ class Application(Gtk.Application):
     def on_help_url(self, action, param):
         webbrowser.open_new_tab(param.get_string())
 
-    def on_hi(self, action, param):
+    def on_instr_setup(self, action, param):
 
         hi_dialog = Gtk.MessageDialog(type = Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.CLOSE)
         hi_dialog.run()

--- a/rfi_file_monitor/application.py
+++ b/rfi_file_monitor/application.py
@@ -9,7 +9,7 @@ import webbrowser
 import logging
 
 from .applicationwindow import ApplicationWindow
-from .utils import add_action_entries
+from .utils import add_action_entries, ComboBoxWindow
 
 class Application(Gtk.Application):
 
@@ -127,6 +127,6 @@ class Application(Gtk.Application):
         webbrowser.open_new_tab(param.get_string())
 
     def on_instr_setup(self, action, param):
+            new_box = ComboBoxWindow()
+            new_box.show_all()
 
-        hi_dialog = Gtk.MessageDialog(type = Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.CLOSE)
-        hi_dialog.run()

--- a/rfi_file_monitor/application.py
+++ b/rfi_file_monitor/application.py
@@ -40,7 +40,8 @@ class Application(Gtk.Application):
             ("quit", self.on_quit),
             ("open", self.on_open),
             ("new", lambda *_: self.do_activate()),
-            ("help-url", self.on_help_url, "s")
+            ("help-url", self.on_help_url, "s"),
+            ('hi', self.on_hi)
         )
 
         # This doesn't work, which is kind of uncool
@@ -124,3 +125,8 @@ class Application(Gtk.Application):
 
     def on_help_url(self, action, param):
         webbrowser.open_new_tab(param.get_string())
+
+    def on_hi(self, action, param):
+
+        hi_dialog = Gtk.MessageDialog(type = Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.CLOSE)
+        hi_dialog.run()

--- a/rfi_file_monitor/application.py
+++ b/rfi_file_monitor/application.py
@@ -9,7 +9,7 @@ import webbrowser
 import logging
 
 from .applicationwindow import ApplicationWindow
-from .utils import add_action_entries, ComboBoxWindow
+from .utils import add_action_entries, SetUpComboBox
 
 class Application(Gtk.Application):
 
@@ -127,6 +127,6 @@ class Application(Gtk.Application):
         webbrowser.open_new_tab(param.get_string())
 
     def on_instr_setup(self, action, param):
-            new_box = ComboBoxWindow()
+            new_box = SetUpComboBox()
             new_box.show_all()
 

--- a/rfi_file_monitor/applicationwindow.py
+++ b/rfi_file_monitor/applicationwindow.py
@@ -54,7 +54,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, WidgetParams):
             ("save", self.on_save),
             ("save-as", self.on_save_as),
             ("close", self.on_close),
-            ("minimize", self.on_minimize),
+            ("minimize", self.on_minimize)
         )
 
         # This doesn't work, which is kind of uncool
@@ -501,7 +501,6 @@ class ApplicationWindow(Gtk.ApplicationWindow, WidgetParams):
                 dialog.destroy()
         else:
             dialog.destroy()
-        
 
     def files_dict_timeout_cb(self, *user_data):
         """
@@ -572,6 +571,7 @@ class ApplicationWindow(Gtk.ApplicationWindow, WidgetParams):
         self._controls_operations_button.set_sensitive(False)
         for operation in self._operations_box:
             operation.set_sensitive(False)
+
 
 class PreflightCheckThread(Thread):
     def __init__(self, appwindow: ApplicationWindow, task_window: LongTaskWindow):

--- a/rfi_file_monitor/data/menus-appmenu.ui
+++ b/rfi_file_monitor/data/menus-appmenu.ui
@@ -8,13 +8,6 @@
 				<attribute name="action">app.about</attribute>
 			</item>
 		</section>
-		<!--<section>
-			<attribute name="id">section2</attribute>
-			<item>
-				<attribute name="label">_Preferences</attribute>
-				<attribute name="action">app.preferences</attribute>
-			</item>
-		</section>-->
 		<section>
 			<attribute name="id">section3</attribute>
 			<item>

--- a/rfi_file_monitor/data/menus-common.ui
+++ b/rfi_file_monitor/data/menus-common.ui
@@ -83,10 +83,10 @@
 			<submenu>
 			<attribute name="label">_Preferences</attribute>
 				<section>
-					<attribute name="id">hi</attribute>
+					<attribute name="id">instr-setup</attribute>
 					<item>
 						<attribute name="label">Setup Instrument</attribute>
-						<attribute name="action">app.hi</attribute>
+						<attribute name="action">app.instr-setup</attribute>
 					</item>
 				</section>
 			</submenu>

--- a/rfi_file_monitor/data/menus-common.ui
+++ b/rfi_file_monitor/data/menus-common.ui
@@ -81,6 +81,16 @@
 				</section>
 			</submenu>
 			<submenu>
+			<attribute name="label">_Preferences</attribute>
+				<section>
+					<attribute name="id">hi</attribute>
+					<item>
+						<attribute name="label">Setup Instrument</attribute>
+						<attribute name="action">app.hi</attribute>
+					</item>
+				</section>
+			</submenu>
+			<submenu>
 				<attribute name="label">_Help</attribute>
 				<section>
 					<attribute name="id">help-url-section</attribute>

--- a/rfi_file_monitor/utils.py
+++ b/rfi_file_monitor/utils.py
@@ -138,3 +138,30 @@ class LongTaskWindow(Gtk.Window):
 
     def set_text(self, text: str):
         self._label.set_markup(text)
+
+class ComboBoxWindow(Gtk.Window):
+    def __init__(self):
+        Gtk.Window.__init__(self, title="Select Instrument")
+
+        self.set_border_width(10)
+
+        name_store = Gtk.ListStore(str)
+        name_list= ['Instrument1', 'Instrument2', 'Instrument3']
+        for nm in name_list:
+            name_store.append([nm])
+
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing =6)
+
+        name_combo = Gtk.ComboBox.new_with_model_and_entry(name_store)
+        name_combo.connect("changed", self.on_name_combo_changed)
+        name_combo.set_entry_text_column(0)
+        vbox.pack_start(name_combo, False, False,  0)
+
+        self.add(vbox)
+
+    def on_name_combo_changed(self, combo):
+        tree_iter = combo.get_active_iter()
+        if tree_iter is not None:
+            model = combo.get_model()
+            name = model[tree_iter][:1]
+            print(name)

--- a/rfi_file_monitor/utils.py
+++ b/rfi_file_monitor/utils.py
@@ -152,16 +152,16 @@ class SetUpComboBox(Gtk.Window):
         for nm in name_list:
             name_store.append([nm])
 
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing =6)
+        vgrid = Gtk.Grid()
 
         name_combo = Gtk.ComboBox.new_with_model_and_entry(name_store)
         name_combo.connect("changed", self.on_name_combo_changed)
         name_combo.set_entry_text_column(0)
-        vbox.pack_start(name_combo, False, False,  0)
+        vgrid.attach(name_combo, 1,0,2,1)
 
         self.label = Gtk.Label("")
-        vbox.pack_start(self.label , False , False , True)
-        self.add(vbox)
+        vgrid.attach(self.label ,1,2,1,1)
+        self.add(vgrid)
 
     def on_name_combo_changed(self, combo):
         tree_iter = combo.get_active_iter()
@@ -171,6 +171,6 @@ class SetUpComboBox(Gtk.Window):
             self.label.set_label("selected instrument: {instrument}".format(instrument=name[0]))
 
     def get_instruments_from_yaml(self):
-        instr_file= open('rfi-instruments.yaml')
-        instruments= yaml.load(instr_file, Loader=yaml.FullLoader)
-        return instruments.keys()
+        with open('rfi-instruments.yaml') as instr_file:
+            instruments = yaml.load(instr_file, Loader=yaml.FullLoader)
+            return instruments.keys()

--- a/rfi_file_monitor/utils.py
+++ b/rfi_file_monitor/utils.py
@@ -139,7 +139,7 @@ class LongTaskWindow(Gtk.Window):
     def set_text(self, text: str):
         self._label.set_markup(text)
 
-class ComboBoxWindow(Gtk.Window):
+class SetUpComboBox(Gtk.Window):
     def __init__(self):
         Gtk.Window.__init__(self, title="Select Instrument")
 
@@ -157,6 +157,8 @@ class ComboBoxWindow(Gtk.Window):
         name_combo.set_entry_text_column(0)
         vbox.pack_start(name_combo, False, False,  0)
 
+        self.label = Gtk.Label("")
+        vbox.pack_start(self.label , False , False , True)
         self.add(vbox)
 
     def on_name_combo_changed(self, combo):
@@ -164,4 +166,4 @@ class ComboBoxWindow(Gtk.Window):
         if tree_iter is not None:
             model = combo.get_model()
             name = model[tree_iter][:1]
-            print(name)
+            self.label.set_label("selected instrument: {instrument}".format(instrument=name[0]))

--- a/rfi_file_monitor/utils.py
+++ b/rfi_file_monitor/utils.py
@@ -5,6 +5,7 @@ from munch import Munch
 
 from typing import Callable, Optional, Final, Any, Dict, final
 import logging
+import yaml
 
 EXPAND_AND_FILL: Final[Dict[str, Any]] = dict(hexpand=True, vexpand=True, halign=Gtk.Align.FILL, valign=Gtk.Align.FILL)
 
@@ -146,7 +147,8 @@ class SetUpComboBox(Gtk.Window):
         self.set_border_width(10)
 
         name_store = Gtk.ListStore(str)
-        name_list= ['Instrument1', 'Instrument2', 'Instrument3']
+
+        name_list= self.get_instruments_from_yaml()
         for nm in name_list:
             name_store.append([nm])
 
@@ -167,3 +169,8 @@ class SetUpComboBox(Gtk.Window):
             model = combo.get_model()
             name = model[tree_iter][:1]
             self.label.set_label("selected instrument: {instrument}".format(instrument=name[0]))
+
+    def get_instruments_from_yaml(self):
+        instr_file= open('rfi-instruments.yaml')
+        instruments= yaml.load(instr_file, Loader=yaml.FullLoader)
+        return instruments.keys()

--- a/rfi_file_monitor/utils.py
+++ b/rfi_file_monitor/utils.py
@@ -165,12 +165,14 @@ class SetUpComboBox(Gtk.Window):
 
     def on_name_combo_changed(self, combo):
         tree_iter = combo.get_active_iter()
-        if tree_iter is not None:
+        if tree_iter:
             model = combo.get_model()
             name = model[tree_iter][:1]
-            self.label.set_label("selected instrument: {instrument}".format(instrument=name[0]))
+            self.label.set_label(f"selected instrument: {name[0]}")
 
     def get_instruments_from_yaml(self):
+
         with open('rfi-instruments.yaml') as instr_file:
             instruments = yaml.load(instr_file, Loader=yaml.FullLoader)
             return instruments.keys()
+

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(
     license="BSD license",
     #test_suite="tests",
     url="https://github.com/rosalindfranklininstitute/rfi-file-monitor",
+    include_package_date=True,
 )


### PR DESCRIPTION
Need to set up the instrument details as an environmental variable so that we can use them in the cataloguing software. This is currently implemented with a Preferences > Set Up Instrument menu.

Instruments are defined in rfi-instrument.yaml and are displayed to a user in a combo box.

Once the user has selected this an environmental variable will be set for the instrument which will be used elsewhere in the software and extensions.

Currently wip as env variable setting has not been completed. 