### PR TITLE
Bugsnag: use only in production

### DIFF
--- a/rfi_file_monitor/__init__.py
+++ b/rfi_file_monitor/__init__.py
@@ -16,6 +16,7 @@ bugsnag.configure(
     app_version=__version__,
     auto_notify=True,
     auto_capture_sessions=True,
+    notify_release_stages=["production"],
 )
 
 # main entrypoint


### PR DESCRIPTION

Set the BUGSNAG_RELEASE_STAGE environment variable to "development" to
effectively disable bugsnag during development.