### PR TITLE
Modify scicat format

### DIFF
--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -603,9 +603,7 @@ class SciCataloguer(Operation):
             if r:
                 logger.info(f"Payload catalogued, PID: {r}")
         except Exception as e:
-            raise Exception(
-                f"Could not catalogue payload in scicat: {e}"
-            )
+            raise Exception(f"Could not catalogue payload in scicat: {e}")
 
     # Upserts dataset in Scicat
     # This won't work with upserting until features added into PySciCat

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -548,6 +548,7 @@ class SciCataloguer(Operation):
             PayloadHelpers.scientific_metadata_concatenation(
                 scientificMetadata,
                 _pl.scientificMetadataDefaults,
+                self.params.additional_metadata,
             )
         )
 
@@ -574,6 +575,7 @@ class SciCataloguer(Operation):
             PayloadHelpers.scientific_metadata_concatenation(
                 scientificMetadata,
                 _pl.scientificMetadataDefaults,
+                self.params.additional_metadata,
             )
         )
 
@@ -697,8 +699,11 @@ class PayloadHelpers:
         return source_folders
 
     @classmethod
-    def scientific_metadata_concatenation(cls, scientific_metadata, defaults):
+    def scientific_metadata_concatenation(
+        cls, scientific_metadata, defaults, additional
+    ):
         scientific_metadata |= defaults
+        scientific_metadata |= additional
         return scientific_metadata
 
 

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -460,6 +460,8 @@ class SciCataloguer(Operation):
 
     def run(self, file: File):
         self.params.keywords = []
+        # This can be added manually in future? TO DO
+        self.params.additional_metadata = {}
         return self._run(file, self.params)
 
     def _run(self, file: File, params):

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -525,76 +525,76 @@ class SciCataloguer(Operation):
         return payload
 
     # Adds file specific payload data
-    def is_file_payload(self, _pl, file):
-        _pl.datasetName = (
+    def is_file_payload(self, _payload, file):
+        _payload.datasetName = (
             self.params.experiment_name
             + "/"
             + str(PurePosixPath(file.relative_filename))
         )
         fstats = Path(file.filename).stat()
-        _pl.size = fstats.st_size
+        _payload.size = fstats.st_size
 
         # Scientific metadata
         scientificMetadata = {}
-        _pl.scientificMetadata = (
+        _payload.scientificMetadata = (
             PayloadHelpers.scientific_metadata_concatenation(
                 scientificMetadata,
-                _pl.scientificMetadataDefaults,
+                _payload.scientificMetadataDefaults,
                 self.params.additional_metadata,
             )
         )
 
-        _pl.creationTime = (
+        _payload.creationTime = (
             datetime.fromtimestamp(
                 Path(file.filename).stat().st_ctime
             ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
             + "Z"
         )
-        return _pl
+        return _payload
 
     # Adds directory specific payload data
-    def is_dir_payload(self, _pl, file):
-        _pl.datasetName = (
+    def is_dir_payload(self, _payload, file):
+        _payload.datasetName = (
             self.params.experiment_name
             + "/"
             + str(file.relative_filename.parts[-1])
         )
-        _pl.size = file._total_size
-        _pl.numberOfFiles = len(file._filelist)
+        _payload.size = file._total_size
+        _payload.numberOfFiles = len(file._filelist)
 
         # Scientific metadata
         scientificMetadata: Dict[str, Dict[str, str]] = {}
-        _pl.scientificMetadata = (
+        _payload.scientificMetadata = (
             PayloadHelpers.scientific_metadata_concatenation(
                 scientificMetadata,
-                _pl.scientificMetadataDefaults,
+                _payload.scientificMetadataDefaults,
                 self.params.additional_metadata,
             )
         )
 
-        _pl.creationTime = (
+        _payload.creationTime = (
             datetime.fromtimestamp(file._filelist_timestamp).strftime(
                 "%Y-%m-%dT%H:%M:%S.%f"
             )[:-3]
             + "Z"
         )
 
-        return _pl
+        return _payload
 
     # Adds raw dataset specific data
-    def is_raw_payload(self, _pl, _data_format):
-        _pl.creationLocation = str(self.params.instrument_choice)
-        _pl.principalInvestigator = self.params.investigator
-        _pl.endTime = _pl.creationTime
-        _pl.dataFormat = _data_format
-        return _pl
+    def is_raw_payload(self, _payload, _data_format):
+        _payload.creationLocation = str(self.params.instrument_choice)
+        _payload.principalInvestigator = self.params.investigator
+        _payload.endTime = _payload.creationTime
+        _payload.dataFormat = _data_format
+        return _payload
 
     # Adds derived dataset specific data
-    def is_derived_payload(self, _pl):
-        _pl.investigator = self.params.investigator
-        _pl.inputDatasets = self.params.input_datasets.split(",")
-        _pl.usedSoftware = self.params.used_software.split(",")
-        return _pl
+    def is_derived_payload(self, _payload):
+        _payload.investigator = self.params.investigator
+        _payload.inputDatasets = self.params.input_datasets.split(",")
+        _payload.usedSoftware = self.params.used_software.split(",")
+        return _payload
 
     # Inserts a dataset into Scicat
     def insert_payload(self, payload, scicat_session):

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -525,7 +525,7 @@ class SciCataloguer(Operation):
                 )[:-3]
                 + "Z"
             ),
-            keywords=params.keywords
+            keywords=params.keywords,
         )
 
         # Add in raw/derived specific variables

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -4,7 +4,6 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from datetime import datetime
 from ..operation import Operation
-from ..utils import query_metadata
 from ..file import File
 from ..files.directory import Directory
 from ..files.regular_file import RegularFile
@@ -40,7 +39,7 @@ class SciCataloguer(Operation):
         # Hostname
         self._grid.attach(
             Gtk.Label(
-                label="SciCat Hostname",
+                label=" SciCat Hostname ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -65,7 +64,7 @@ class SciCataloguer(Operation):
         # Operation upload
         self._grid.attach(
             Gtk.Label(
-                label="Upload location ",
+                label=" Upload location ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -87,7 +86,7 @@ class SciCataloguer(Operation):
         # Username
         self._grid.attach(
             Gtk.Label(
-                label="Username",
+                label=" Username ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -112,7 +111,7 @@ class SciCataloguer(Operation):
         # Password
         self._grid.attach(
             Gtk.Label(
-                label="Password",
+                label=" Password ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -138,7 +137,7 @@ class SciCataloguer(Operation):
         # Owner
         self._grid.attach(
             Gtk.Label(
-                label="Owner",
+                label=" Owner ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -163,7 +162,7 @@ class SciCataloguer(Operation):
         # Owner group
         self._grid.attach(
             Gtk.Label(
-                label="Owner Group",
+                label=" Owner Group ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -188,7 +187,7 @@ class SciCataloguer(Operation):
         # Comtact email
         self._grid.attach(
             Gtk.Label(
-                label="Email",
+                label=" Email ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -213,7 +212,7 @@ class SciCataloguer(Operation):
         # Orcid
         self._grid.attach(
             Gtk.Label(
-                label="Orcid",
+                label=" Orcid ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -238,7 +237,7 @@ class SciCataloguer(Operation):
         # PI
         self._grid.attach(
             Gtk.Label(
-                label="Principal Investigator",
+                label=" Principal Investigator ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -263,7 +262,7 @@ class SciCataloguer(Operation):
         # Dataset name
         self._grid.attach(
             Gtk.Label(
-                label="Experiment name",
+                label=" Experiment name ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -289,7 +288,7 @@ class SciCataloguer(Operation):
         # TO DO - this is temporary until instrument preferences configured
         self._grid.attach(
             Gtk.Label(
-                label="Instrument",
+                label=" Instrument ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -314,7 +313,7 @@ class SciCataloguer(Operation):
         # Technique
         self._grid.attach(
             Gtk.Label(
-                label="Technique",
+                label=" Technique ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -339,7 +338,7 @@ class SciCataloguer(Operation):
         # Input boxes for derived dataset specific fields
         self._grid.attach(
             Gtk.Label(
-                label="Input Datasets",
+                label=" Input Datasets ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -365,7 +364,7 @@ class SciCataloguer(Operation):
 
         self._grid.attach(
             Gtk.Label(
-                label="Used Software",
+                label=" Used Software ",
                 halign=Gtk.Align.START,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
@@ -396,6 +395,19 @@ class SciCataloguer(Operation):
         )
         self._grid.attach(self._derived_checkbox, 0, 6, 1, 1)
 
+    def checkbox_toggled(self, checkbox):
+        # Set class attribute for derived/raw dataset
+        if checkbox.get_active() == True:
+            self.params.derived_dataset = True
+            self._input_datasets_entry.set_sensitive(True)
+            self._used_software_entry.set_sensitive(True)
+            return True
+        elif checkbox.get_active() == False:
+            self.params.derived_dataset = False
+            self._input_datasets_entry.set_sensitive(False)
+            self._used_software_entry.set_sensitive(False)
+            return False
+
     @staticmethod
     def _check_required_fields(params):
         if not params.hostname:
@@ -411,34 +423,21 @@ class SciCataloguer(Operation):
         if not params.owner_group:
             raise RequiredInfoNotFound("Owner group required")
 
-    def checkbox_toggled(self, checkbox):
-        # Set class attribute for derived/raw dataset
-        if checkbox.get_active() == True:
-            self.params.derived_dataset = True
-            self._input_datasets_entry.set_sensitive(True)
-            self._used_software_entry.set_sensitive(True)
-            return True
-        elif checkbox.get_active() == False:
-            self.params.derived_dataset = False
-            self._input_datasets_entry.set_sensitive(False)
-            self._used_software_entry.set_sensitive(False)
-            return False
-
     def preflight_check(self):
+        self._preflight_check(self.params)
+
+    def _preflight_check(self, params):
         try:
             ScicatClient(
-                base_url=self.params.hostname,
-                username=self.params.username,
-                password=self.params.password,
+                base_url=params.hostname,
+                username=params.username,
+                password=params.password,
             )
         except Exception as e:
             logger.error(f"Could not login to scicat: {e}")
+            return str(e)
 
-        # check that metadata requirements are met
-        self.session_starter_info = query_metadata(
-            self.appwindow.preflight_check_metadata, "orcid", full_dict=True
-        )
-        self._check_required_fields(self.params)
+        self._check_required_fields(params)
 
         self.operations_list = [
             op.get_child().NAME
@@ -453,21 +452,21 @@ class SciCataloguer(Operation):
             )
 
         # Check that a technique has been selected for instruments that might have more than one technique
-        if not self.params.technique:
+        if not params.technique:
             raise RequiredInfoNotFound(
                 "Please name a technique for this instrument."
             )
 
-    def run(self, file: File):
+    def _run(self, file: File, params):
 
         # Create the payload
-        payload = self.create_payload(file)
+        payload = self.create_payload(file, params)
         try:
             try:
                 scicat_session = ScicatClient(
-                    base_url=self.params.hostname,
-                    username=self.params.username,
-                    password=self.params.password,
+                    base_url=params.hostname,
+                    username=params.username,
+                    password=params.password,
                 )
             except Exception as e:
                 logger.error(f"Could not login to scicat: {e}")
@@ -479,10 +478,14 @@ class SciCataloguer(Operation):
         else:
             return None
 
-    def create_payload(self, file):
+    def run(self, file: File):
+        self.params.keywords = []
+        return self._run(file, self.params)
+
+    def create_payload(self, file, params):
         # Extract relevant fields before initialising Payload
         host_info = PayloadHelpers.get_host_location(
-            file, self.operations_list, self.params.operation
+            file, self.operations_list, params.operation
         )
         # TO DO - reinstate when instr_dict configured
         # if "access groups" in self.instr_dict:
@@ -510,40 +513,41 @@ class SciCataloguer(Operation):
             sourceFolderHost=host_info["sourceFolderHost"],
             # TO DO - this would normally be extracted from instrument preferences
             # instrumentId=str(self.instr_dict["id"]),
-            owner=self.params.owner,
-            contactEmail=self.params.email,
-            orcidOfOwner=self.params.orcid,
-            ownerGroup=self.params.owner_group,
+            owner=params.owner,
+            contactEmail=params.email,
+            orcidOfOwner=params.orcid,
+            ownerGroup=params.owner_group,
             accessGroups=access_groups,
-            techniques=[{"name": self.params.technique}],
+            techniques=[{"name": params.technique}],
             creationTime=(
                 datetime.fromtimestamp(date_method).strftime(
                     "%Y-%m-%dT%H:%M:%S.%f"
                 )[:-3]
                 + "Z"
             ),
+            keywords=params.keywords
         )
 
         # Add in raw/derived specific variables
-        if self.params.derived_dataset:
+        if params.derived_dataset:
             payload = DerivedPayload(**default_payload.dict())
             payload.type = "derived"
-            payload.investigator = self.params.investigator
-            payload.inputDatasets = self.params.input_datasets.split(",")
-            payload.usedSoftware = self.params.used_software.split(",")
+            payload.investigator = params.investigator
+            payload.inputDatasets = params.input_datasets.split(",")
+            payload.usedSoftware = params.used_software.split(",")
         else:
             payload = RawPayload(**default_payload.dict())
             # TO DO this usually comes from instr dict
             # Temporary change to fetch from text box for now
-            payload.creationLocation = str(self.params.instrument_choice)
-            payload.principalInvestigator = self.params.investigator
+            payload.creationLocation = str(params.instrument_choice)
+            payload.principalInvestigator = params.investigator
             payload.endTime = payload.creationTime
             payload.dataFormat = data_format
 
         # Add in Directory specific payload details
         if isinstance(file, Directory):
             payload.datasetName = (
-                self.params.experiment_name
+                params.experiment_name
                 + "/"
                 + str(file.relative_filename.parts[-1])
             )

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -40,7 +40,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" SciCat Hostname ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -65,7 +65,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Upload location ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -87,7 +87,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Username ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -112,7 +112,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Password ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -138,7 +138,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Owner ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -163,7 +163,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Owner Group ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -188,7 +188,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Email ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -213,7 +213,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Orcid ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -238,7 +238,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Principal Investigator ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -263,7 +263,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Experiment name ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -289,7 +289,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Instrument ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,
@@ -314,7 +314,7 @@ class SciCataloguer(Operation):
         self._grid.attach(
             Gtk.Label(
                 label=" Technique ",
-                halign=Gtk.Align.START,
+                halign=Gtk.Align.CENTER,
                 valign=Gtk.Align.CENTER,
                 hexpand=False,
                 vexpand=False,

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -428,6 +428,7 @@ class SciCataloguer(Operation):
         self._preflight_check(self.params)
 
     def _preflight_check(self, params):
+        self._check_required_fields(params)
         try:
             ScicatClient(
                 base_url=params.hostname,
@@ -435,10 +436,7 @@ class SciCataloguer(Operation):
                 password=params.password,
             )
         except Exception as e:
-            logger.error(f"Could not login to scicat: {e}")
-            return str(e)
-
-        self._check_required_fields(params)
+            raise Exception(f"Could not login to scicat: {e}")
 
         self.operations_list = [
             op.get_child().NAME
@@ -476,12 +474,10 @@ class SciCataloguer(Operation):
                     password=params.password,
                 )
             except Exception as e:
-                logger.error(f"Could not login to scicat: {e}")
-                return str(e)
+                raise Exception(f"Could not login to scicat: {e}")
             self.upsert_payload(payload, scicat_session)
         except Exception as e:
-            logger.exception(f"Scicataloger.run exception")
-            return str(e)
+            raise Exception(f"Scicataloger.run exception")
         else:
             return None
 
@@ -607,10 +603,9 @@ class SciCataloguer(Operation):
             if r:
                 logger.info(f"Payload catalogued, PID: {r}")
         except Exception as e:
-            logger.error(
-                f"Could not catalogue payload in scicat: {e.statusCode} -> {e.message}"
+            raise Exception(
+                f"Could not catalogue payload in scicat: {e}"
             )
-            return str(e)
 
     # Upserts dataset in Scicat
     # This won't work with upserting until features added into PySciCat
@@ -630,7 +625,7 @@ class SciCataloguer(Operation):
                 # if r:
                 #    logger.info(f"Payload upserted, PID: {r}")
                 # except Exception as e:
-                #   logger.error(f"Could not catalogue payload in scicat: {e}")
+                #   raise Exception(f"Could not catalogue payload in scicat: {e}")
                 #   return str(e)
             else:
                 self.insert_payload(payload, scicat_session)

--- a/rfi_file_monitor/operations/scicataloguer.py
+++ b/rfi_file_monitor/operations/scicataloguer.py
@@ -523,6 +523,7 @@ class SciCataloguer(Operation):
 
         # Add in raw/derived specific variables
         if params.derived_dataset:
+            default_payload.type = "derived"
             payload = DerivedPayload(**default_payload.dict())
             payload = self.is_derived_payload(payload)
         else:
@@ -641,8 +642,9 @@ class SciCataloguer(Operation):
 
 # Base Payload Model inherits from Dataset Model
 class Payload(Dataset):
-    type: Optional[str]
+    type: Optional[str] = "raw"
     datasetlifecycle = {"retrievable": True}
+    scientificMetadata = {}
     scientificMetadataDefaults = {}
     scientificMetadataDefaults["RFI File Monitor Version"] = {
         "type": "string",
@@ -653,13 +655,11 @@ class Payload(Dataset):
 
 # Extends Payload for raw data
 class RawPayload(RawDataset, Payload):
-    type: Optional[str] = "raw"
     dataFormat: Optional[str]
 
 
 # Extends Payload for derived data
 class DerivedPayload(DerivedDataset, Payload):
-    type: Optional[str] = "derived"
     inputDatasets: Optional[List[str]]
     usedSoftware: Optional[List[str]]
 


### PR DESCRIPTION
This pr modified the Scicataloguer operation to allow it to be inherited from. It also reshuffles some of the functions to make it more coherent/tidy. A parameter for `additional_metadata` was also added and included in the metadata concatenation. This allows the extension default metadata to be added in, and provides framework for other metadata that is not parsed from the file to be added in (something that will be added later in another pr)